### PR TITLE
Fix code scanning alert no. 8: Expression injection in Actions

### DIFF
--- a/.github/workflows/update-stable.yml
+++ b/.github/workflows/update-stable.yml
@@ -59,11 +59,12 @@ jobs:
 
       - name: Determine Version Bump
         id: version_bump
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
-          if [[ $COMMIT_MSG =~ "#release:major" ]]; then
+          if [[ "$COMMIT_MSG" =~ "#release:major" ]]; then
             echo "bump=major" >> $GITHUB_OUTPUT
-          elif [[ $COMMIT_MSG =~ "#release:minor" ]]; then
+          elif [[ "$COMMIT_MSG" =~ "#release:minor" ]]; then
             echo "bump=minor" >> $GITHUB_OUTPUT
           else
             echo "bump=patch" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fixes [https://github.com/drzo/bolt.diy-v2/security/code-scanning/8](https://github.com/drzo/bolt.diy-v2/security/code-scanning/8)

To fix the problem, we should avoid using the commit message directly in the script. Instead, we should set the commit message to an intermediate environment variable and use the shell's native syntax to access this variable. This approach prevents any potential injection by ensuring that the commit message is treated as a plain string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
