### PR TITLE
Fix code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/app/components/workbench/Preview.tsx
+++ b/app/components/workbench/Preview.tsx
@@ -1,5 +1,6 @@
 import { useStore } from '@nanostores/react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import DOMPurify from 'dompurify';
 import { IconButton } from '~/components/ui/IconButton';
 import { workbenchStore } from '~/lib/stores/workbench';
 import { PortDropdown } from './PortDropdown';
@@ -240,7 +241,7 @@ export const Preview = memo(() => {
             }}
             onKeyDown={(event) => {
               if (event.key === 'Enter' && validateUrl(url)) {
-                setIframeUrl(url);
+                setIframeUrl(DOMPurify.sanitize(url));
 
                 if (inputRef.current) {
                   inputRef.current.blur();

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
     "remix-island": "^0.2.0",
     "remix-utils": "^7.7.0",
     "shiki": "^1.24.0",
-    "unist-util-visit": "^5.0.0"
+    "unist-util-visit": "^5.0.0",
+    "dompurify": "^3.2.3"
   },
   "devDependencies": {
     "@blitz/eslint-plugin": "0.1.0",


### PR DESCRIPTION
Fixes [https://github.com/drzo/bolt.diy-v2/security/code-scanning/7](https://github.com/drzo/bolt.diy-v2/security/code-scanning/7)

To fix the problem, we need to ensure that the URL provided by the user is properly sanitized before being used as the `src` attribute of the `iframe`. This can be achieved by using a library like `DOMPurify` to sanitize the URL. We will import `DOMPurify` and use it to sanitize the `url` before setting it as the `iframeUrl`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
