### PR TITLE
Fix code scanning alert no. 6: Clear text transmission of sensitive cookie

### DIFF
--- a/app/components/settings/connections/ConnectionsTab.tsx
+++ b/app/components/settings/connections/ConnectionsTab.tsx
@@ -65,14 +65,14 @@ export default function ConnectionsTab() {
     const isValid = await verifyGitHubCredentials();
 
     if (isValid) {
-      Cookies.set('githubUsername', githubUsername);
-      Cookies.set('githubToken', githubToken);
+      Cookies.set('githubUsername', githubUsername, { secure: true, httpOnly: true });
+      Cookies.set('githubToken', githubToken, { secure: true, httpOnly: true });
       logStore.logSystem('GitHub connection settings updated', {
         username: githubUsername,
         hasToken: !!githubToken,
       });
       toast.success('GitHub credentials verified and saved successfully!');
-      Cookies.set('git:github.com', JSON.stringify({ username: githubToken, password: 'x-oauth-basic' }));
+      Cookies.set('git:github.com', JSON.stringify({ username: githubToken, password: 'x-oauth-basic' }), { secure: true, httpOnly: true });
       setIsConnected(true);
     } else {
       toast.error('Invalid GitHub credentials. Please check your username and token.');


### PR DESCRIPTION
Fixes [https://github.com/drzo/bolt.diy-v2/security/code-scanning/6](https://github.com/drzo/bolt.diy-v2/security/code-scanning/6)

To fix the problem, we need to ensure that the cookies are only transmitted over secure connections by setting the `secure` attribute when setting the cookies. This can be done by modifying the `Cookies.set` calls to include the `secure` attribute. Additionally, it is a good practice to set the `httpOnly` attribute to prevent client-side scripts from accessing the cookies, further enhancing security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
